### PR TITLE
Fix update_geneset to ensure functionnality

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Install `python 3.8` with [pyenv](https://github.com/pyenv/pyenv)
 
 ```
 brew install pyenv
-pyenv install 3.8
-pyenv local 3.8
+pyenv install 3.8.0
+pyenv local 3.8.0
 ```
 
 Copy/paste at the following command at the end of your `.zshrc` or `.bash_rc`
@@ -52,7 +52,7 @@ We need to install [poetry](https://python-poetry.org/docs/#installation) to man
 You can make sure poetry is correctly installed by running 
 
 ````
-poetry version
+poetry --version
 ````
 
 Then, install dependencies `poetry install`.

--- a/backend/crud.py
+++ b/backend/crud.py
@@ -18,8 +18,8 @@ def update_geneset(db: Session, geneset_id: int, title: str, genes: List[str]):
     geneset.title = title
 
     db.query(Gene).filter(Gene.geneset_id == geneset_id).delete()
-    for gene_name in genes:
-        geneset.genes.append(Gene(name=gene_name))
+    for gene in genes:
+        geneset.genes.append(Gene(name=gene.name))
 
     db.commit()
     return geneset

--- a/backend/crud.py
+++ b/backend/crud.py
@@ -1,4 +1,5 @@
 from sqlalchemy.orm import Session
+from typing import List
 
 
 from models import Gene, Geneset
@@ -11,9 +12,17 @@ def get_geneset(db: Session, geneset_id: int):
 
     return db.query(Geneset).filter(Geneset.id == geneset_id).first()
 
-def update_geneset(db: Session, geneset_id: int):
+def update_geneset(db: Session, geneset_id: int, title: str, genes: List[str]):
 
-    return db.query(Geneset).filter(Geneset.id == geneset_id).first()
+    geneset = db.query(Geneset).filter(Geneset.id == geneset_id).first()
+    geneset.title = title
+
+    db.query(Gene).filter(Gene.geneset_id == geneset_id).delete()
+    for gene_name in genes:
+        geneset.genes.append(Gene(name=gene_name))
+
+    db.commit()
+    return geneset
 
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -34,9 +34,9 @@ def read_geneset(geneset_id: int, db: Session = Depends(get_db)):
     return crud.get_geneset(db, geneset_id)
 
 
-@app.put("/genesets/update/{geneset_id}", response_model=schemas.Geneset)
-def update_genesets(geneset_id: int, title: str, genes: str, db: Session = Depends(get_db)):
-    return crud.update_geneset(db, geneset_id, title, genes.split(","))
+@app.put("/genesets/{geneset_id}", response_model=schemas.Geneset)
+def update_genesets(geneset_id: int, geneset: schemas.GenesetCreate, db: Session = Depends(get_db)):
+    return crud.update_geneset(db, geneset_id, geneset.title, geneset.genes)
 
 
 @app.post("/genesets")

--- a/backend/main.py
+++ b/backend/main.py
@@ -31,13 +31,13 @@ def read_match_genesets(pattern: str, db: Session = Depends(get_db)):
 
 @app.get("/genesets/{geneset_id}", response_model=schemas.Geneset)
 def read_geneset(geneset_id: int, db: Session = Depends(get_db)):
-
     return crud.get_geneset(db, geneset_id)
 
-@app.put("/genesets/{geneset_id}")
-def update_genesets(geneset_id: int, db: Session = Depends(get_db)):
 
-    return crud.get_geneset(db, geneset_id)
+@app.put("/genesets/update/{geneset_id}", response_model=schemas.Geneset)
+def update_genesets(geneset_id: int, title: str, genes: str, db: Session = Depends(get_db)):
+    return crud.update_geneset(db, geneset_id, title, genes.split(","))
+
 
 @app.post("/genesets")
 def create_geneset(geneset: schemas.GenesetCreate, db: Session = Depends(get_db)):


### PR DESCRIPTION
Three main modifications are included in this PR:
- Rewrite update_genesets to correctly use crud.update_geneset.
- Rewrite update_geneset to correctly change a geneset in the database.
- Update README.md with better informations for install.

Please note:
- The URL to update a geneset is a PUT build like this one: http://127.0.0.1:8000/genesets/1 with a JSON body similar to this one:

```
{
    "title": "MY_CUSTOM_GENESET",
    "genes": [
        {"name": "aaa"}, 
        {"name": "bbb"}, 
        {"name": "ccc"}
    ]
}
```
- Empty `genes` are now supported